### PR TITLE
Adding keys that will be used to access the keeper store

### DIFF
--- a/x/csr/module.go
+++ b/x/csr/module.go
@@ -125,7 +125,7 @@ func (am AppModule) Route() sdk.Route {
 }
 
 // QuerierRoute returns the capability module's query routing key.
-func (AppModule) QuerierRoute() string { return types.QuerierRoute }
+func (AppModule) QuerierRoute() string { return types.RouterKey }
 
 // LegacyQuerierHandler returns the capability module's Querier.
 func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sdk.Querier {

--- a/x/csr/types/interfaces.go
+++ b/x/csr/types/interfaces.go
@@ -1,0 +1,31 @@
+package types
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/evmos/ethermint/x/evm/statedb"
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
+)
+
+// AccountKeeper defines the expected interface needed to retrieve account info.
+type AccountKeeper interface {
+	GetModuleAddress(moduleName string) sdk.AccAddress
+}
+
+// BankKeeper defines the expected interface needed to retrieve account balances.
+type BankKeeper interface {
+	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+	BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
+	GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin
+	GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
+}
+
+// EVMKeeper defines the expected EVM keeper interface used on erc20
+type EVMKeeper interface {
+	EVMConfig(ctx sdk.Context) (*evmtypes.EVMConfig, error)
+	GetParams(ctx sdk.Context) evmtypes.Params
+	GetAccountWithoutBalance(ctx sdk.Context, addr common.Address) *statedb.Account
+}

--- a/x/csr/types/keys.go
+++ b/x/csr/types/keys.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"strconv"
-
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -24,8 +22,8 @@ const (
 	prefixSmartContract
 	// deployer address -> csr pool addresses
 	prefixDeployer
-	// smart contract address + NFT id -> last withdraw period
-	prefixLastPeriodNFT
+	// smart contract address -> NFTs
+	prefixNFT
 )
 
 // KVStore key prefixes
@@ -33,11 +31,10 @@ var (
 	KeyPrefixCSR           = []byte{prefixCSR}
 	KeyPrefixSmartContract = []byte{prefixSmartContract}
 	KeyPrefixDeployer      = []byte{prefixDeployer}
-	KeyPrefixLastPeriodNFT = []byte{prefixLastPeriodNFT}
+	KeyPrefixNFT           = []byte{prefixNFT}
 )
 
 // Multi-tier index to find the latest withdrawal period for an NFT
-func GetKeyPrefixLastPeriodNFT(contractAddress common.Address, id uint64) []byte {
-	contractPrefix := append(KeyPrefixLastPeriodNFT, contractAddress.Bytes()...)
-	return append(contractPrefix, []byte(strconv.FormatUint(id, 10))...)
+func GetKeyPrefixLastPeriodNFT(contractAddress common.Address) []byte {
+	return append(KeyPrefixNFT, contractAddress.Bytes()...)
 }

--- a/x/csr/types/keys.go
+++ b/x/csr/types/keys.go
@@ -1,5 +1,11 @@
 package types
 
+import (
+	"strconv"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
 const (
 	// ModuleName defines the module name
 	ModuleName = "csr"
@@ -9,18 +15,29 @@ const (
 
 	// RouterKey is the message route for slashing
 	RouterKey = ModuleName
-
-    // QuerierRoute defines the module's query routing key
-    QuerierRoute = ModuleName
-
-	// MemStoreKey defines the in-memory store key
-	MemStoreKey = "mem_csr"
-
-    
 )
 
+const (
+	// csr pool address -> csr struct
+	prefixCSR = iota + 1
+	// smartContract -> csr pool address
+	prefixSmartContract
+	// deployer address -> csr pool addresses
+	prefixDeployer
+	// smart contract address + NFT id -> last withdraw period
+	prefixLastPeriodNFT
+)
 
+// KVStore key prefixes
+var (
+	KeyPrefixCSR           = []byte{prefixCSR}
+	KeyPrefixSmartContract = []byte{prefixSmartContract}
+	KeyPrefixDeployer      = []byte{prefixDeployer}
+	KeyPrefixLastPeriodNFT = []byte{prefixLastPeriodNFT}
+)
 
-func KeyPrefix(p string) []byte {
-    return []byte(p)
+// Multi-tier index to find the latest withdrawal period for an NFT
+func GetKeyPrefixLastPeriodNFT(contractAddress common.Address, id uint64) []byte {
+	contractPrefix := append(KeyPrefixLastPeriodNFT, contractAddress.Bytes()...)
+	return append(contractPrefix, []byte(strconv.FormatUint(id, 10))...)
 }

--- a/x/csr/types/keys.go
+++ b/x/csr/types/keys.go
@@ -1,8 +1,6 @@
 package types
 
-import (
-	"github.com/ethereum/go-ethereum/common"
-)
+import sdk "github.com/cosmos/cosmos-sdk/types"
 
 const (
 	// ModuleName defines the module name
@@ -22,19 +20,22 @@ const (
 	prefixSmartContract
 	// deployer address -> csr pool addresses
 	prefixDeployer
-	// smart contract address -> NFTs
-	prefixNFT
+	// csr pool address -> current period
+	prefixCurrentPeriod
+	// csr pool address -> cumulative rewards
+	prefixCumulativeRewards
 )
 
 // KVStore key prefixes
 var (
-	KeyPrefixCSR           = []byte{prefixCSR}
-	KeyPrefixSmartContract = []byte{prefixSmartContract}
-	KeyPrefixDeployer      = []byte{prefixDeployer}
-	KeyPrefixNFT           = []byte{prefixNFT}
+	KeyPrefixCSR               = []byte{prefixCSR}
+	KeyPrefixSmartContract     = []byte{prefixSmartContract}
+	KeyPrefixDeployer          = []byte{prefixDeployer}
+	KeyPrefixCurrentPeriod     = []byte{prefixCurrentPeriod}
+	KeyPrefixCumulativeRewards = []byte{prefixCumulativeRewards}
 )
 
-// Multi-tier index to find the latest withdrawal period for an NFT
-func GetKeyPrefixLastPeriodNFT(contractAddress common.Address) []byte {
-	return append(KeyPrefixNFT, contractAddress.Bytes()...)
+// Get the key for the pool so that we can extract rewards at a given period
+func GetKeyPrefixPoolRewards(poolAddress sdk.AccAddress) []byte {
+	return append(KeyPrefixCumulativeRewards, poolAddress.Bytes()...)
 }


### PR DESCRIPTION
In this PR, I add the first set of keys that will be used in the store.

1. prefixCSR –> takes the CSR Pool address (which will be a bech32 address) and returns the CSR struct it corresponds to.
2. prefixSmartContract –> takes an EVM smart contract address (sec256k) and returns the CSR pool that the object belongs to.
3. prefixDeployer –> takes the deployer address and finds all of the CSR pool addresses that the has initialized
4. prefixLastPeriodNFT –> takes the address of the smart contract and token id of an NFT and returns the last period the NFT withdrew revenue from.