### PR TITLE
Correct the go.mod v2 <> v5.0.0 mismatch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Canto-Network/Canto/v2
+module github.com/Canto-Network/Canto/v5
 
 go 1.18
 


### PR DESCRIPTION
It is impossible to import a Canto module (e.g. GovShuttle) with a version mismatch in go.mod, in particular
`go get github.com/canto-network/canto/v2@v5.0.0` will panic with the following error:
invalid version: module path includes a major version suffix, so major version must match

The next step is to release a v5.0.1 version including this commit.