### PR TITLE
ci: Migrate to paths-filter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,21 +21,23 @@ jobs:
       matrix:
         go-arch: ["amd64"]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "^1.21"
-      - uses: technote-space/get-diff-action@v6.1.2
-        id: git_diff
+      - uses: dorny/paths-filter@v3
+        id: filter
         with:
-          PATTERNS: |
-            **/*.go
-            go.mod
-            go.sum
-            **/go.mod
-            **/go.sum
-            **/Makefile
-            Makefile
+          filters: |
+            go:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - '**/go.mod'
+              - '**/go.sum'
+              - '**/Makefile'
+              - 'Makefile'
+
       - name: Build
-        if: env.GIT_DIFF
+        if: steps.filter.outputs.go == 'true'
         run: GOARCH=${{ matrix.go-arch }} LEDGER_ENABLED=false make build


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

The technote-space/get-diff-action repo is no longer maintained and archived. Last commit was 2 years ago.
On the other hand dorny/paths-filter is actively maintained, last commit was 6 months ago and has far more stars 2100 vs 190 for get-diff-action. Last but not least paths-filter would better handle push force scenario.

Also bump actions versions to keep the CI up to date.

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted the correct branch (see [PR Targeting](https://github.com/canto-network/canto/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration tests
- [x] reviewed "Files changed" and left comments if necessary
 
### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
