### PR TITLE
ci: Upload static build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,22 +20,32 @@ jobs:
     strategy:
       matrix:
         go-arch: ["amd64"]
+        go-os: ["linux"]
+    env:
+      GOARCH: ${{ matrix.go-arch }}
+      GOOS: ${{ matrix.go-os }}
+      LEDGER_ENABLED: false
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "^1.21"
-      - uses: technote-space/get-diff-action@v6.1.2
-        id: git_diff
+      - name: Non-static Build
+        run: |
+          make build
+          mv ./build/cantod ./build/cantod-nonstatic-${{ matrix.go-os }}-${{ matrix.go-arch }}
+      - name: Install musl-tools
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Static Build
+        env:
+          CC: musl-gcc
+          LDFLAGS: "-extldflags -static"
+        run: |
+          rm -r build
+          make build
+          mv build/cantod ./build/cantod-${{ matrix.go-os }}-${{ matrix.go-arch }}
+      - name: Upload cantod Binary (Static)
+        uses: actions/upload-artifact@v4
         with:
-          PATTERNS: |
-            **/*.go
-            go.mod
-            go.sum
-            **/go.mod
-            **/go.sum
-            **/Makefile
-            Makefile
-      - name: Build
-        if: env.GIT_DIFF
-        run: GOARCH=${{ matrix.go-arch }} LEDGER_ENABLED=false make build
+          name: cantod-${{ matrix.go-os }}-${{ matrix.go-arch }}
+          path: ./build/cantod-${{ matrix.go-os }}-${{ matrix.go-arch }}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Make static builds and upload them as artifacts.
This makes it possible to download the binary produced for each PR. In a follow up PR we could also automate binary upload upon release as well as enabling cross compilation for different arch and OS.

Note that we use musl-gcc as it allows to statically link a libc implementation while CGO_ENABLED=0 only was leading to the error below:
```
ethermint@v0.22.0-sdk50-1/app/ante/eip712.go:293:36: undefined: secp256k1.RecoverPubkey
ethermint@v0.22.0-sdk50-1/app/ante/eip712.go:319:17: undefined: secp256k1.VerifySignature
```
The statically linked binary is 100M as of today.

Also drop get-diff-action as it's unmaintained and was misbehaving on the rebasing and squashing workflow, refs #139

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted the correct branch (see [PR Targeting](https://github.com/canto-network/canto/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration tests
- [x] reviewed "Files changed" and left comments if necessary
 
### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
