### PR TITLE
ci: Fix the Dockerfile and build from CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,13 @@
+name: Docker Build
+on:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - run: docker build --tag=canto-network/canto .
+      - run: docker run --volume --rm canto-network/canto

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,12 @@
-FROM golang:stretch AS build-env
+FROM golang:1.21 AS build-env
 
 WORKDIR /go/src/github.com/canto/canto
-
-RUN apt-get update -y
-RUN apt-get install git -y
 
 COPY . .
 
 RUN make build
 
-FROM golang:stretch
-
-RUN apt-get update -y
-RUN apt-get install ca-certificates jq -y
+FROM debian:12-slim
 
 WORKDIR /root
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Becoming A Validator
 
+[![Build Canto Core](https://github.com/Canto-Network/Canto/actions/workflows/build.yml/badge.svg)](https://github.com/Canto-Network/Canto/actions/workflows/build.yml)
+[![Docker Build](https://github.com/Canto-Network/Canto/actions/workflows/docker.yml/badge.svg)](https://github.com/Canto-Network/Canto/actions/workflows/docker.yml)
+[![Sims](https://github.com/Canto-Network/Canto/actions/workflows/sims.yml/badge.svg)](https://github.com/Canto-Network/Canto/actions/workflows/sims.yml)
+[![Tests / Code Coverage](https://github.com/Canto-Network/Canto/actions/workflows/test.yml/badge.svg)](https://github.com/Canto-Network/Canto/actions/workflows/test.yml)
+
 **How to validate on the Canto Mainnet**
 
 *(canto_7700-1)*


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Fix the Dockerfile and add the Docker build to the CI.
The docker build error was:
```
1.359 E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found
1.359 E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found
1.359 E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found
1.359 E: Some index files failed to download. They have been ignored, or old ones used instead.
```

Also use a minimal image for the final build stage. New image size is 240MB vs 4.4G for the old one.

In a follow up PR we could add multi-arch build support and automatic image upload to Docker registries.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted the correct branch (see [PR Targeting](https://github.com/canto-network/canto/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration tests
- [x] reviewed "Files changed" and left comments if necessary
 
### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
